### PR TITLE
Example of calling `visitCallElement` instead of using custom logic.

### DIFF
--- a/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
@@ -354,11 +354,17 @@ class FormatterKtTest {
   fun `binary operators dont break when the last one is a lambda`() =
       assertFormatted(
           """
-      |----------------------
-      |foo =
-      |    foo + bar + dsl {
-      |      baz = 1
-      |    }
+      |------------------------
+      |fun binaryOps() {
+      |  foo =
+      |      foo + bar + dsl {
+      |        baz = 1
+      |      }
+      |  boo =
+      |      boo + ba + f(1) {
+      |        bam = 1
+      |      }
+      |}
       |""".trimMargin(),
           deduceMaxWidth = true)
 

--- a/core/src/test/java/com/facebook/ktfmt/GoogleStyleFormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/GoogleStyleFormatterKtTest.kt
@@ -455,11 +455,17 @@ class GoogleStyleFormatterKtTest {
   fun `binary operators dont break when the last one is a lambda`() =
       assertFormatted(
           """
-      |--------------------
-      |foo =
-      |  foo + bar + dsl {
-      |    baz = 1
-      |  }
+      |-----------------------
+      |fun binaryOps() {
+      |  foo =
+      |    foo + bar + dsl {
+      |      baz = 1
+      |    }
+      |  boo =
+      |    boo + ba + f(1) {
+      |      bam = 1
+      |    }
+      |}
       |""".trimMargin(),
           formattingOptions = GOOGLE_FORMAT,
           deduceMaxWidth = true)


### PR DESCRIPTION
This is an example of calling `visitCallElement` in `processLambdaOrScopingFunction`. It allows the process function to handle lambdas with arguments or type arguments.

Also as an example, this also modifies the `lambdaOrScopingFunction` to return `true` for lambdas with arguments or type arguments.

While this passes unit tests, **I have no real-life code to test this against** because I'm using a different box. My dev box is currently having some auth issues working with github and it's taking a while to resolve them.