### PR TITLE
De-inline OpsBuilder.block()

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -2480,7 +2480,7 @@ class KotlinInputAstVisitor(
    * @param plusIndent the block level to pass to the block
    * @param block a code block to be run in this block level
    */
-  private inline fun OpsBuilder.block(
+  private fun OpsBuilder.block(
       plusIndent: Indent,
       isEnabled: Boolean = true,
       block: () -> Unit


### PR DESCRIPTION
As implemented, this function is unsafe to inline. Outer return from the callback would skip the call to builder.close().