### PR TITLE
Enforce blank lines between class members

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -45,6 +45,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtCatchClause
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassInitializer
 import org.jetbrains.kotlin.psi.KtClassLiteralExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -170,10 +171,9 @@ class KotlinInputAstVisitor(
           true,
           function.valueParameterList,
           function.typeConstraintList,
-          function.bodyBlockExpression,
-          function.bodyExpression,
+          function.bodyBlockExpression ?: function.bodyExpression,
           function.typeReference,
-          function.bodyBlockExpression?.lBrace != null)
+      )
     }
   }
 
@@ -289,10 +289,8 @@ class KotlinInputAstVisitor(
       emitParenthesis: Boolean,
       parameterList: KtParameterList?,
       typeConstraintList: KtTypeConstraintList?,
-      bodyBlockExpression: KtBlockExpression?,
-      nonBlockBodyExpressions: KtExpression?,
+      bodyExpression: KtExpression?,
       typeOrDelegationCall: KtElement?,
-      emitBraces: Boolean
   ) {
     builder.block(ZERO) {
       if (modifierList != null) {
@@ -361,19 +359,19 @@ class KotlinInputAstVisitor(
         builder.space()
         visit(typeConstraintList)
       }
-      if (bodyBlockExpression != null) {
+      if (bodyExpression is KtBlockExpression) {
         builder.space()
-        visitBlockBody(bodyBlockExpression, emitBraces)
-      } else if (nonBlockBodyExpressions != null) {
+        visit(bodyExpression)
+      } else if (bodyExpression != null) {
         builder.space()
         builder.block(ZERO) {
           builder.token("=")
-          if (isLambdaOrScopingFunction(nonBlockBodyExpressions)) {
-            visitLambdaOrScopingFunction(nonBlockBodyExpressions)
+          if (isLambdaOrScopingFunction(bodyExpression)) {
+            visitLambdaOrScopingFunction(bodyExpression)
           } else {
             builder.block(expressionBreakIndent) {
               builder.breakOp(Doc.FillMode.INDEPENDENT, " ", ZERO)
-              builder.block(ZERO) { visit(nonBlockBodyExpressions) }
+              builder.block(ZERO) { visit(bodyExpression) }
             }
           }
         }
@@ -389,23 +387,22 @@ class KotlinInputAstVisitor(
     return Output.BreakTag()
   }
 
-  private fun visitBlockBody(bodyBlockExpression: PsiElement, emitBraces: Boolean) {
-    if (emitBraces) {
-      builder.token("{", Doc.Token.RealOrImaginary.REAL, blockIndent, Optional.of(blockIndent))
-    }
+  private fun emitBracedBlock(
+      bodyBlockExpression: PsiElement,
+      emitChildren: (Array<PsiElement>) -> Unit,
+  ) {
+    builder.token("{", Doc.Token.RealOrImaginary.REAL, blockIndent, Optional.of(blockIndent))
     val statements = bodyBlockExpression.children
     if (statements.isNotEmpty()) {
       builder.block(blockIndent) {
         builder.forcedBreak()
         builder.blankLineWanted(OpsBuilder.BlankLineWanted.PRESERVE)
-        visitStatements(statements)
+        emitChildren(statements)
       }
       builder.forcedBreak()
       builder.blankLineWanted(OpsBuilder.BlankLineWanted.NO)
     }
-    if (emitBraces) {
-      builder.token("}", blockIndent)
-    }
+    builder.token("}", blockIndent)
   }
 
   private fun visitStatement(statement: PsiElement) {
@@ -1384,10 +1381,9 @@ class KotlinInputAstVisitor(
                 accessor.bodyExpression != null || accessor.bodyBlockExpression != null,
                 accessor.parameterList,
                 null,
-                accessor.bodyBlockExpression,
-                accessor.bodyExpression,
+                accessor.bodyBlockExpression ?: accessor.bodyExpression,
                 accessor.returnTypeReference,
-                accessor.bodyBlockExpression?.lBrace != null)
+            )
           }
         }
       }
@@ -1488,57 +1484,11 @@ class KotlinInputAstVisitor(
         visit(typeConstraintList)
         builder.space()
       }
-      val body = classOrObject.body
-      if (classOrObject.hasModifier(KtTokens.ENUM_KEYWORD)) {
-        visitEnumBody(classOrObject as KtClass)
-      } else if (body != null) {
-        visitBlockBody(body, true)
-      }
+      visit(classOrObject.body)
     }
     if (classOrObject.nameIdentifier != null) {
       builder.forcedBreak()
     }
-  }
-
-  /** Example `{ RED, GREEN; fun foo() { ... } }` for an enum class */
-  private fun visitEnumBody(enumClass: KtClass) {
-    val body = enumClass.body
-    if (body == null) {
-      return
-    }
-    builder.token("{", Doc.Token.RealOrImaginary.REAL, blockIndent, Optional.of(blockIndent))
-    builder.open(ZERO)
-    builder.block(blockIndent) {
-      builder.breakOp(Doc.FillMode.UNIFIED, "", ZERO)
-      val (enumEntries, nonEnumEntryStatements) = body.children.partition { it is KtEnumEntry }
-      builder.forcedBreak()
-      visitEnumEntries(enumEntries)
-
-      if (nonEnumEntryStatements.isNotEmpty()) {
-        builder.forcedBreak()
-        builder.blankLineWanted(OpsBuilder.BlankLineWanted.PRESERVE)
-        visitStatements(nonEnumEntryStatements.toTypedArray())
-      }
-    }
-    builder.forcedBreak()
-    builder.blankLineWanted(OpsBuilder.BlankLineWanted.NO)
-    builder.token("}", blockIndent)
-    builder.close()
-  }
-
-  /** Example `RED, GREEN, BLUE,` in an enum class, or `RED, GREEN;` */
-  private fun visitEnumEntries(enumEntries: List<PsiElement>) {
-    builder.block(ZERO) {
-      builder.breakOp(Doc.FillMode.UNIFIED, "", ZERO)
-      for (value in enumEntries) {
-        visit(value)
-        if (builder.peekToken() == Optional.of(",")) {
-          builder.token(",")
-          builder.forcedBreak()
-        }
-      }
-    }
-    builder.guessToken(";")
   }
 
   override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
@@ -1568,11 +1518,9 @@ class KotlinInputAstVisitor(
 
   /** Example `private constructor(n: Int) : this(4, 5) { ... }` inside a class's body */
   override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {
-    val delegationCall = constructor.getDelegationCall()
-    val bodyExpression = constructor.bodyExpression
-
     builder.sync(constructor)
 
+    val delegationCall = constructor.getDelegationCall()
     visitFunctionLikeExpression(
         constructor.modifierList,
         "constructor",
@@ -1582,10 +1530,9 @@ class KotlinInputAstVisitor(
         true,
         constructor.valueParameterList,
         null,
-        bodyExpression,
-        null,
+        constructor.bodyExpression,
         if (!delegationCall.isImplicit) delegationCall else null,
-        true)
+    )
   }
 
   override fun visitConstructorDelegationCall(call: KtConstructorDelegationCall) {
@@ -1897,9 +1844,55 @@ class KotlinInputAstVisitor(
     }
   }
 
+  override fun visitClassBody(body: KtClassBody) {
+    builder.sync(body)
+    emitBracedBlock(body) { children ->
+      val (enumEntries, nonEnumEntryMembers) = children.partition { it is KtEnumEntry }
+
+      if (enumEntries.isNotEmpty()) {
+        builder.block(ZERO) {
+        builder.breakOp(Doc.FillMode.UNIFIED, "", ZERO)
+          for (value in enumEntries) {
+            visit(value)
+            if (builder.peekToken() == Optional.of(",")) {
+              builder.token(",")
+              builder.forcedBreak()
+            }
+          }
+        }
+        builder.guessToken(";")
+
+        if (nonEnumEntryMembers.isNotEmpty()) {
+          builder.forcedBreak()
+          builder.blankLineWanted(OpsBuilder.BlankLineWanted.YES)
+        }
+      }
+
+      var prev: PsiElement? = null
+      for (curr in nonEnumEntryMembers) {
+        val blankLineBetweenMembers = when {
+          prev == null -> OpsBuilder.BlankLineWanted.PRESERVE
+          prev !is KtProperty -> OpsBuilder.BlankLineWanted.YES
+          prev.getter != null || prev.setter != null -> OpsBuilder.BlankLineWanted.YES
+          curr is KtProperty -> OpsBuilder.BlankLineWanted.PRESERVE
+          else -> OpsBuilder.BlankLineWanted.YES
+        }
+        builder.blankLineWanted(blankLineBetweenMembers)
+
+        builder.block(ZERO) { visit(curr) }
+        builder.guessToken(";")
+        builder.forcedBreak()
+
+        prev = curr
+      }
+    }
+  }
+
   override fun visitBlockExpression(expression: KtBlockExpression) {
     builder.sync(expression)
-    visitBlockBody(expression, true)
+    emitBracedBlock(expression) { children ->
+      visitStatements(children)
+    }
   }
 
   override fun visitWhenConditionWithExpression(condition: KtWhenConditionWithExpression) {
@@ -2347,10 +2340,9 @@ class KotlinInputAstVisitor(
       visit(enumEntry.modifierList)
       builder.token(enumEntry.nameIdentifier?.text ?: fail())
       enumEntry.initializerList?.initializers?.forEach { visit(it) }
-      val body = enumEntry.body
-      if (body != null) {
+      enumEntry.body?.let {
         builder.space()
-        visitBlockBody(body, true)
+        visit(it)
       }
     }
   }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -264,7 +264,9 @@ class FormatterTest {
           """
       |class Foo(a: Int, var b: Double, val c: String) {
       |  val x = 2
+      |
       |  fun method() {}
+      |
       |  class Bar
       |}
       |"""
@@ -276,8 +278,11 @@ class FormatterTest {
           """
       |class Foo(public val p1: Int, private val p2: Int, open val p3: Int, final val p4: Int) {
       |  private var f1 = 0
+      |
       |  public var f2 = 0
+      |
       |  open var f3 = 0
+      |
       |  final var f4 = 0
       |}
       |"""
@@ -500,19 +505,22 @@ class FormatterTest {
   @Test
   fun `properties with accessors`() =
       assertFormatted(
-          """
+        """
       |class Foo {
       |  var x: Int
       |    get() = field
+      |
       |  var y: Boolean
       |    get() = x.equals(123)
       |    set(value) {
       |      field = value
       |    }
+      |
       |  var z: Boolean
       |    get() {
       |      x.equals(123)
       |    }
+      |
       |  var zz = false
       |    private set
       |}
@@ -525,7 +533,9 @@ class FormatterTest {
         """
       |class Foo {
       |  var x = false; private set
+      |
       |  internal val a by lazy { 5 }; internal get
+      |
       |  var foo: Int; get() = 6; set(x) {};
       |}
       |"""
@@ -536,8 +546,10 @@ class FormatterTest {
       |class Foo {
       |  var x = false
       |    private set
+      |
       |  internal val a by lazy { 5 }
       |    internal get
+      |
       |  var foo: Int
       |    get() = 6
       |    set(x) {}
@@ -2231,6 +2243,7 @@ class FormatterTest {
           """
       |class Foo private constructor(number: Int) {
       |  private constructor(n: Float) : this(1)
+      |
       |  private constructor(n: Double) : this(1) {
       |    println("built")
       |  }
@@ -4299,6 +4312,7 @@ class FormatterTest {
       |  TRUE,
       |  FALSE,
       |  FILE_NOT_FOUND;
+      |
       |  fun isGood(): Boolean {
       |    return true
       |  }
@@ -4345,8 +4359,7 @@ class FormatterTest {
   fun `handle empty enum`() =
       assertFormatted(
           """
-      |enum class YTho {
-      |}
+      |enum class YTho {}
       |"""
               .trimMargin())
 
@@ -6494,6 +6507,109 @@ class FormatterTest {
       |"""
               .trimMargin(),
           deduceMaxWidth = true)
+
+  @Test
+  fun `force blank line between class members`() {
+    val code =
+        """
+      |class Foo {
+      |  val x = 0
+      |  fun foo() {}
+      |  class Bar {}
+      |  enum class Enum {
+      |    A {
+      |      val x = 0
+      |      fun foo() {}
+      |    };
+      |    abstract fun foo(): Unit
+      |  }
+      |}
+      |"""
+            .trimMargin()
+
+    val expected =
+        """
+      |class Foo {
+      |  val x = 0
+      |
+      |  fun foo() {}
+      |
+      |  class Bar {}
+      |
+      |  enum class Enum {
+      |    A {
+      |      val x = 0
+      |
+      |      fun foo() {}
+      |    };
+      |
+      |    abstract fun foo(): Unit
+      |  }
+      |}
+      |"""
+            .trimMargin()
+
+    assertThatFormatting(code).isEqualTo(expected)
+  }
+
+  @Test
+  fun `preserve blank line between class members between properties`() {
+    val code =
+        """
+      |class Foo {
+      |  val x = 0
+      |  val x = 0
+      |
+      |  val x = 0
+      |}
+      |"""
+            .trimMargin()
+
+    assertThatFormatting(code).isEqualTo(code)
+  }
+
+  @Test
+  fun `force blank line between class members preserved between properties with accessors`() {
+    val code =
+        """
+      |class Foo {
+      |  val _x = 0
+      |  val x = 0
+      |    private get
+      |  val y = 0
+      |}
+      |
+      |class Foo {
+      |  val _x = 0
+      |  val x = 0
+      |    private set
+      |  val y = 0
+      |}
+      |"""
+            .trimMargin()
+
+    val expected =
+        """
+      |class Foo {
+      |  val _x = 0
+      |  val x = 0
+      |    private get
+      |
+      |  val y = 0
+      |}
+      |
+      |class Foo {
+      |  val _x = 0
+      |  val x = 0
+      |    private set
+      |
+      |  val y = 0
+      |}
+      |"""
+            .trimMargin()
+
+    assertThatFormatting(code).isEqualTo(expected)
+  }
 
   companion object {
     /** Triple quotes, useful to use within triple-quoted strings. */


### PR DESCRIPTION
This change is effectively a separation of the behaviour for block-bodies vs block-expressions. In doing so, several simplifications were uncovered.