### PR TITLE
Plugin doesn't work with if "Only VCS changed text" is selected from code-reformat settings

### DIFF
--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtCodeStyleManager.java
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtCodeStyleManager.java
@@ -26,10 +26,13 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.ChangedRangesInfo;
 import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.impl.CheckUtil;
 import com.intellij.util.IncorrectOperationException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -64,6 +67,17 @@ class KtfmtCodeStyleManager extends CodeStyleManagerDecorator {
     } else {
       super.reformatText(file, ranges);
     }
+  }
+
+  @Override
+  public void reformatTextWithContext(@NotNull PsiFile file, @NotNull ChangedRangesInfo info)
+      throws IncorrectOperationException {
+    List<TextRange> ranges = new ArrayList<>();
+    if (info.insertedRanges != null) {
+      ranges.addAll(info.insertedRanges);
+    }
+    ranges.addAll(info.allChangedRanges);
+    reformatTextWithContext(file, ranges);
   }
 
   @Override


### PR DESCRIPTION
Fixes facebook/ktfmt#228 

The code reformat with "Only VCS changed text" falls back to the IDE Kotlin settings due to a missing override in KtfmtCodeStyleManager.java. This is also true of the popular "Save Actions" plugin which reformats with the same command.

This change adds the missing override exactly as it appears in the reference project google/google-java-format at https://github.com/google/google-java-format/blob/d86e930de93f123994fba151a8d289b8035db87b/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatCodeStyleManager.java#L76

Confirmed to fix the issue on Android Studio 2021.1.1 with the manual code-reformat and in the Save Actions plugin.