### PR TITLE
Don't insert blank lines between line comments at the end of files

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -2390,16 +2390,19 @@ class KotlinInputAstVisitor(
 
   override fun visitKtFile(file: KtFile) {
     markForPartialFormat()
-    var importListEmpty = false
+    val importListEmpty = file.importList?.text?.isBlank() ?: true
+
     var isFirst = true
     for (child in file.children) {
-      if (child.text.isBlank()) {
-        importListEmpty = child is KtImportList
-        continue
-      }
-      if (!isFirst && child !is PsiComment && (child !is KtScript || !importListEmpty)) {
-        builder.blankLineWanted(OpsBuilder.BlankLineWanted.YES)
-      }
+      if (child.text.isBlank()) continue
+
+      builder.blankLineWanted(when {
+        isFirst -> OpsBuilder.BlankLineWanted.NO
+        child is PsiComment -> OpsBuilder.BlankLineWanted.NO
+        child is KtScript && importListEmpty -> OpsBuilder.BlankLineWanted.PRESERVE
+        else -> OpsBuilder.BlankLineWanted.YES
+      })
+
       visit(child)
       isFirst = false
     }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -440,7 +440,7 @@ class FormatterTest {
           deduceMaxWidth = true)
 
   @Test
-  fun `don't keep adding newlines between these two comments when they're at end of file`() =
+  fun `don't keep adding newlines between these two comments when they're at end of file`() {
       assertFormatted(
           """
      |package foo
@@ -449,6 +449,37 @@ class FormatterTest {
      |/* Another comment */
      |"""
               .trimMargin())
+
+    assertFormatted(
+          """
+     |// Comment as first element
+     |package foo
+     |// a
+     |
+     |/* Another comment */
+     |"""
+              .trimMargin())
+
+    assertFormatted(
+          """
+     |// Comment as first element then blank line
+     |
+     |package foo
+     |// a
+     |
+     |/* Another comment */
+     |"""
+              .trimMargin())
+
+    assertFormatted(
+          """
+     |// Comment as first element
+     |package foo
+     |// Adjacent line comments
+     |// Don't separate
+     |"""
+              .trimMargin())
+  }
 
   @Test
   fun `properties with line comment above initializer`() =


### PR DESCRIPTION
There was already code/testing for this, but it wasn't covering a strange case where a comment was the first line of the file.