### PR TITLE
Preserve a trailing space when lambda only has block comments

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -890,6 +890,7 @@ class KotlinInputAstVisitor(
     val valueParams = lambdaExpression.valueParameters
     val hasParams = valueParams.isNotEmpty()
     val statements = (lambdaExpression.bodyExpression ?: fail()).children
+    val hasComments = lambdaExpression.bodyExpression?.children()?.any { it is PsiComment } ?: false
     val hasStatements = statements.isNotEmpty()
     val hasArrow = lambdaExpression.functionLiteral.arrow != null
 
@@ -945,7 +946,7 @@ class KotlinInputAstVisitor(
       }
     }
 
-    if (hasParams || hasArrow || hasStatements) {
+    if (hasParams || hasArrow || hasStatements || hasComments) {
       // If we had to break in the body, ensure there is a break before the closing brace
       builder.breakOp(Doc.FillMode.UNIFIED, " ", bracePlusZeroIndent)
     }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -5809,6 +5809,15 @@ class FormatterTest {
               .trimMargin())
 
   @Test
+  fun `lambda with only comments`() =
+      assertFormatted(
+          """
+      |val a = { /* do nothing */ }
+      |val b = { /* do nothing */ /* also do nothing */ }
+      |"""
+              .trimMargin())
+
+  @Test
   fun `chaining - many dereferences`() =
       assertFormatted(
           """

--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtConfigurable.java
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtConfigurable.java
@@ -200,9 +200,7 @@ public class KtfmtConfigurable extends BaseConfigurable implements SearchableCon
             false));
   }
 
-  /**
-   * @noinspection ALL
-   */
+  /** @noinspection ALL */
   public JComponent $$$getRootComponent$$$() {
     return panel;
   }


### PR DESCRIPTION
This fixes #408