### PR TITLE
Force annotations to newlines on properties

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -54,6 +54,7 @@ import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
 import org.jetbrains.kotlin.psi.KtContainerNode
 import org.jetbrains.kotlin.psi.KtContextReceiverList
 import org.jetbrains.kotlin.psi.KtContinueExpression
+import org.jetbrains.kotlin.psi.KtDeclarationModifierList
 import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
 import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
@@ -1854,6 +1855,16 @@ class KotlinInputAstVisitor(
         null, // Type-arguments are included in the annotation's callee expression.
         annotationEntry.valueArgumentList,
         listOf())
+
+    // Annotations on properties should each be on their own line
+    if (
+      annotationEntry.parent != null &&
+      annotationEntry.parent::class == KtDeclarationModifierList::class &&
+      annotationEntry.parent.parent != null &&
+      annotationEntry.parent.parent::class == KtProperty::class
+    ) {
+      builder.forcedBreak()
+    }
   }
 
   override fun visitFileAnnotationList(

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -1528,8 +1528,13 @@ class FormatterTest {
       |@Fancy
       |class Foo {
       |  @Fancy
+      |  @NotFancy
+      |  val z = 0
+      |
+      |  @Fancy
       |  fun baz(@Fancy foo: Int) {
-      |    @Fancy val a = 1 + foo
+      |    @Fancy
+      |    val a = 1 + foo
       |  }
       |}
       |"""
@@ -2369,6 +2374,24 @@ class FormatterTest {
       |"""
               .trimMargin(),
           deduceMaxWidth = true)
+
+
+  @Test
+  fun `a constructor with many arguments over multiple lines and annotations`() =
+    assertFormatted(
+        """
+    |--------------------------------------------------
+    |data class Foo
+    |constructor(
+    |    @JsonProperty("number_") val number: Int,
+    |    val name: String,
+    |    @JsonProperty("years") val age: Int,
+    |    val title: String,
+    |    val offspring: List<Foo>
+    |) {}
+    |"""
+              .trimMargin(),
+            deduceMaxWidth = true)
 
   @Test
   fun `handle secondary constructors`() =
@@ -4779,9 +4802,11 @@ class FormatterTest {
       assertFormatted(
           """
       |class FooTest {
-      |  @get:Rule val exceptionRule: ExpectedException = ExpectedException.none()
+      |  @get:Rule
+      |  val exceptionRule: ExpectedException = ExpectedException.none()
       |
-      |  @set:Magic(name = "Jane") var field: String
+      |  @set:Magic(name = "Jane")
+      |  var field: String
       |}
       |"""
               .trimMargin())


### PR DESCRIPTION
There are several issues dealing with the surprising fact that annotations end up on the same line as the target (https://github.com/facebook/ktfmt/issues/226, https://github.com/facebook/ktfmt/issues/395, https://github.com/facebook/ktfmt/issues/409). 

@strulovich From what I understand of your comments on these issues, it is uncontroversial to at least have multi-line annotations for properties. This PR attempts that. 