### PR TITLE
Always use UTF8 as the encoding for Kotlin code, regardless of the system/default charset

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,6 +137,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <!-- Tests that everything works when using an unusual default Charset. -->
+                    <argLine>-Dfile.encoding=UTF-16</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/core/src/main/java/com/facebook/ktfmt/cli/ParsedArgs.kt
+++ b/core/src/main/java/com/facebook/ktfmt/cli/ParsedArgs.kt
@@ -20,6 +20,7 @@ import com.facebook.ktfmt.format.Formatter
 import com.facebook.ktfmt.format.FormattingOptions
 import java.io.File
 import java.io.PrintStream
+import java.nio.charset.StandardCharsets.UTF_8
 
 /** ParsedArgs holds the arguments passed to ktfmt on the command-line, after parsing. */
 data class ParsedArgs(
@@ -40,7 +41,7 @@ data class ParsedArgs(
 
     fun processArgs(err: PrintStream, args: Array<String>): ParsedArgs {
       if (args.size == 1 && args[0].startsWith("@")) {
-        return parseOptions(err, File(args[0].substring(1)).readLines().toTypedArray())
+        return parseOptions(err, File(args[0].substring(1)).readLines(UTF_8).toTypedArray())
       } else {
         return parseOptions(err, args)
       }


### PR DESCRIPTION

Closes https://github.com/facebook/ktfmt/issues/373