### PR TITLE
Update google-java-format to 1.22.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
-            <version>1.8</version>
+            <version>1.22.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -479,10 +479,9 @@ class KotlinInputAstVisitor(
         }
       }
       receiver is KtStringTemplateExpression -> {
-        val isMultiline = receiver.text.contains('\n')
         builder.block(expressionBreakIndent) {
           visit(receiver)
-          builder.breakOp(if (isMultiline) Doc.FillMode.FORCED else Doc.FillMode.UNIFIED, "", ZERO)
+          builder.breakOp(Doc.FillMode.UNIFIED, "", ZERO)
           builder.token(expression.operationSign.value)
           visit(expression.selectorExpression)
         }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -2795,8 +2795,14 @@ class FormatterTest {
       assertFormatted(
           """
       |fun doIt(world: String) {
-      |  println(${"\"".repeat(3)}Hello
-      |      world!${"\"".repeat(3)})
+      |  println(
+      |      ${TQ}Hello
+      |      world!${TQ})
+      |  println(
+      |      ${TQ}Hello
+      |      world!${TQ},
+      |      ${TQ}Goodbye
+      |      world!${TQ})
       |}
       |"""
               .trimMargin())
@@ -2806,14 +2812,18 @@ class FormatterTest {
     val code =
         listOf(
                 "fun doIt(world: String) {",
-                "  println(\"\"\"This line has trailing whitespace         ",
-                "      world!\"\"\")",
-                "  println(\"\"\"This line has trailing whitespace \$s     ",
-                "      world!\"\"\")",
-                "  println(\"\"\"This line has trailing whitespace \${s}   ",
-                "      world!\"\"\")",
-                "  println(\"\"\"This line has trailing whitespace \$      ",
-                "      world!\"\"\")",
+                "  println(",
+                "      ${TQ}This line has trailing whitespace         ",
+                "      world!${TQ})",
+                "  println(",
+                "      ${TQ}This line has trailing whitespace \$s     ",
+                "      world!${TQ})",
+                "  println(",
+                "      ${TQ}This line has trailing whitespace \${s}   ",
+                "      world!${TQ})",
+                "  println(",
+                "      ${TQ}This line has trailing whitespace \$      ",
+                "      world!${TQ})",
                 "}",
                 "")
             .joinToString("\n")
@@ -2824,7 +2834,8 @@ class FormatterTest {
   fun `Consecutive line breaks in multiline strings are preserved`() =
       assertFormatted(
           """
-      |val x = $TQ
+      |val x =
+      |    $TQ
       |
       |
       |

--- a/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
@@ -1549,6 +1549,26 @@ class GoogleStyleFormatterKtTest {
           deduceMaxWidth = true)
 
   @Test
+  fun `multiline string literals as function params`() =
+      assertFormatted(
+          """
+      |fun doIt(world: String) {
+      |  println(
+      |    ${TQ}Hello
+      |    world!${TQ}
+      |  )
+      |  println(
+      |    ${TQ}Hello
+      |    world!${TQ},
+      |    ${TQ}Goodbye
+      |    world!${TQ},
+      |  )
+      |}
+      |"""
+              .trimMargin(),
+          formattingOptions = Formatter.GOOGLE_FORMAT)
+
+  @Test
   fun `array-literal in annotation`() =
       assertFormatted(
           """


### PR DESCRIPTION
This update adds support for multiline tokens, which fixes several bugs related to multiline strings.