### PR TITLE
Add pre commit hooks to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Alternatively, you can use [Spotless](https://github.com/diffplug/spotless) with
 
 Consider using [Spotless](https://github.com/diffplug/spotless) with the [ktfmt Maven plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven#ktfmt).
 
+### using pre-commit hooks
+
+A [pre-commit hook](https://pre-commit.com/hooks.html) is implemented in [language-formatters-pre-commit-hooks](https://github.com/macisamuele/language-formatters-pre-commit-hooks)
+
 ## FAQ
 
 ### `ktfmt` vs `ktlint` vs IntelliJ


### PR DESCRIPTION
I've recently added support for ktfmt to pre-commit hooks.

https://github.com/macisamuele/language-formatters-pre-commit-hooks/pull/196

I thought it'd be worth mentioning in the README. 