### PR TITLE
Add support for Gradle assignment operator

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/RedundantImportDetector.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/RedundantImportDetector.kt
@@ -76,7 +76,10 @@ internal class RedundantImportDetector(val enabled: Boolean) {
             // Property delegation operators
             "getValue",
             "setValue",
-            "provideDelegate")
+            "provideDelegate",
+            // assign operator - Gradle compiler plugin https://blog.gradle.org/simpler-kotlin-dsl-property-assignment
+            "assign"
+        )
 
     private val COMPONENT_OPERATOR_REGEX = Regex("component\\d+")
 

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -1451,6 +1451,7 @@ class FormatterTest {
               |import com.example.timesAssign
               |import com.example.unaryMinus
               |import com.example.unaryPlus
+              |import org.gradle.kotlin.dsl.assign
               |"""
               .trimMargin())
 


### PR DESCRIPTION
Fixes #411.

Gradle added support for a [Kotlin assignment operator](https://blog.gradle.org/simpler-kotlin-dsl-property-assignment) to simplify property assignment.

This is done via a compiler plugin and this import: `import org.gradle.kotlin.dsl.assign` - which ktfmt detects as unused and removes.

This PR adds an `assign` operator to the operators in `com.facebook.ktfmt.format.RedundantImportDetector` and a corresponding test to ensure the import remains.