### PR TITLE
add maxWidth option to IDEA plugin, fixes #351

### DIFF
--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtConfigurable.form
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.facebook.ktfmt.intellij.KtfmtConfigurable">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -18,7 +18,7 @@
       </component>
       <vspacer id="19e83">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="c93e1" class="javax.swing.JLabel">
@@ -32,6 +32,20 @@
       <component id="31761" class="javax.swing.JComboBox" binding="styleComboBox" custom-create="true">
         <constraints>
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="1" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="fcf22" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Max width"/>
+        </properties>
+      </component>
+      <component id="bc1eb" class="javax.swing.JFormattedTextField" binding="maxWidthField">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>

--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtConfigurable.java
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtConfigurable.java
@@ -26,11 +26,14 @@ import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.uiDesigner.core.Spacer;
 import java.awt.Insets;
+import java.text.NumberFormat;
+import javax.swing.JFormattedTextField;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.text.NumberFormatter;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,6 +44,7 @@ public class KtfmtConfigurable extends BaseConfigurable implements SearchableCon
   private JPanel panel;
   private JCheckBox enable;
   private JComboBox styleComboBox;
+  private JFormattedTextField maxWidthField;
 
   public KtfmtConfigurable(Project project) {
     this.project = project;
@@ -80,7 +84,9 @@ public class KtfmtConfigurable extends BaseConfigurable implements SearchableCon
   public void apply() throws ConfigurationException {
     KtfmtSettings settings = KtfmtSettings.getInstance(project);
     settings.setEnabled(enable.isSelected() ? EnabledState.ENABLED : getDisabledState());
-    settings.setUiFormatterStyle(((UiFormatterStyle) styleComboBox.getSelectedItem()));
+    UiFormatterStyle selectedStyle = (UiFormatterStyle) styleComboBox.getSelectedItem();
+    settings.setMaxWidth((Integer) maxWidthField.getValue());
+    settings.setUiFormatterStyle(selectedStyle);
   }
 
   private EnabledState getDisabledState() {
@@ -96,13 +102,15 @@ public class KtfmtConfigurable extends BaseConfigurable implements SearchableCon
     KtfmtSettings settings = KtfmtSettings.getInstance(project);
     enable.setSelected(settings.isEnabled());
     styleComboBox.setSelectedItem(settings.getUiFormatterStyle());
+    maxWidthField.setValue(settings.getMaxWidth());
   }
 
   @Override
   public boolean isModified() {
     KtfmtSettings settings = KtfmtSettings.getInstance(project);
     return enable.isSelected() != settings.isEnabled()
-        || !styleComboBox.getSelectedItem().equals(settings.getUiFormatterStyle());
+        || !styleComboBox.getSelectedItem().equals(settings.getUiFormatterStyle())
+        || !maxWidthField.getValue().equals(settings.getMaxWidth());
   }
 
   @Override
@@ -110,6 +118,15 @@ public class KtfmtConfigurable extends BaseConfigurable implements SearchableCon
 
   private void createUIComponents() {
     styleComboBox = new ComboBox<>(UiFormatterStyle.values());
+
+    NumberFormat format = NumberFormat.getInstance();
+    NumberFormatter formatter = new NumberFormatter(format);
+    formatter.setValueClass(Integer.class);
+    formatter.setMinimum(0);
+    formatter.setMaximum(500);
+    formatter.setAllowsInvalid(false);
+
+    maxWidthField = new JFormattedTextField(formatter);
   }
 
   {

--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtSettings.java
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/KtfmtSettings.java
@@ -69,6 +69,14 @@ class KtfmtSettings implements PersistentStateComponent<KtfmtSettings.State> {
     state.uiFormatterStyle = uiFormatterStyle;
   }
 
+  int getMaxWidth() {
+    return state.maxWidth;
+  }
+
+  void setMaxWidth(int maxWidth) {
+    state.maxWidth = maxWidth;
+  }
+
   enum EnabledState {
     UNKNOWN,
     ENABLED,
@@ -79,6 +87,7 @@ class KtfmtSettings implements PersistentStateComponent<KtfmtSettings.State> {
 
     private EnabledState enabled = EnabledState.UNKNOWN;
     public UiFormatterStyle uiFormatterStyle = UiFormatterStyle.META;
+    public int maxWidth = 100;
 
     // enabled used to be a boolean so we use bean property methods for backwards
     // compatibility


### PR DESCRIPTION
<img width="900" alt="Screenshot 2024-07-04 at 15 34 05" src="https://github.com/facebook/ktfmt/assets/68341/31fc92b7-5f0e-40df-ba25-56078de7b45f">

This add a new override option for `maxWidth`, one of the most changed configs.

Unfortunately, working with Kotlin data classes is less than ideal from Java, so new `FormattingOptions` have to be created.