### PR TITLE
Upgrade IJ plugin to new IJP Gradle plugin 2.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,17 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [ 11, 13 ]
+        # test against relevant LTS versions of Java
+        java: [ 17, 21 ]
     name: Build ktfmt on Java ${{ matrix.java }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
+        distribution: zulu
     - name: Build ktfmt
       run: mvn -B install --file pom.xml
     - name: Build ktfmt_idea_plugin

--- a/.github/workflows/publish_artifacts_on_release.yaml
+++ b/.github/workflows/publish_artifacts_on_release.yaml
@@ -15,7 +15,7 @@ on:
       release_tag:
         description: 'Release tag'
         required: true
-        type: stringe
+        type: string
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -24,12 +24,13 @@ jobs:
         with:
           ref: ${{ github.events.release.tag_name || inputs.release_tag || github.ref }}
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+          distribution: zulu
       - id: install-secret-key
         name: Install gpg secret key
         run: |
@@ -53,7 +54,7 @@ jobs:
           popd
         env:
           JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
       - name: Deploy website
         run: |
           KTFMT_TMP_DIR=$(mktemp -d)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle/
 ktfmt_idea_plugin/build/
+ktfmt_idea_plugin/.intellijPlatform/
 .idea/
 *.ims
 *.iml

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
   id("org.jetbrains.intellij") version "1.17.3"
   java
-  id("com.diffplug.spotless") version "5.10.2"
+  id("com.diffplug.spotless") version "6.25.0"
 }
 
 val ktfmtVersion = rootProject.file("../version.txt").readText().trim()

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -39,7 +39,7 @@ java {
 
 dependencies {
   implementation("com.facebook", "ktfmt", ktfmtVersion)
-  implementation("com.google.googlejavaformat", "google-java-format", "1.22.0")
+  implementation("com.google.googlejavaformat", "google-java-format", "1.23.0")
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
@@ -59,4 +59,4 @@ tasks {
   runPluginVerifier { ideVersions.set(listOf("221")) }
 }
 
-spotless { java { googleJavaFormat("1.22.0") } }
+spotless { java { googleJavaFormat("1.23.0") } }

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
 intellijPlatform {
   pluginConfiguration.ideaVersion {
     sinceBuild = "223.7571.182" // 2022.3
+    untilBuild = provider { null }
   }
 
   publishing {

--- a/ktfmt_idea_plugin/gradle.properties
+++ b/ktfmt_idea_plugin/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2G

--- a/ktfmt_idea_plugin/gradle/libs.versions.toml
+++ b/ktfmt_idea_plugin/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+googleJavaFormat = "1.23.0"
+
+# plugins
+gradlePlugin-intelliJPlatform = "2.0.0"
+gradlePlugin-spotless = "6.25.0"
+
+[libraries]
+googleJavaFormat = { module = "com.google.googlejavaformat:google-java-format", version.ref = "googleJavaFormat" }
+
+[plugins]
+intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "gradlePlugin-intelliJPlatform" }
+spotless = { id = "com.diffplug.spotless", version.ref = "gradlePlugin-spotless" }

--- a/ktfmt_idea_plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/ktfmt_idea_plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ktfmt_idea_plugin/src/main/resources/META-INF/plugin.xml
+++ b/ktfmt_idea_plugin/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,6 @@
 <idea-plugin url="https://github.com/facebook/ktfmt/tree/main/ktfmt_idea_plugin">
     <id>com.facebook.ktfmt_idea_plugin</id>
+    <!--suppress PluginXmlCapitalization -->
     <name>ktfmt</name>
     <vendor url="https://github.com/facebook/ktfmt">Facebook</vendor>
 
@@ -13,6 +14,7 @@
         <formattingService
                 implementation="com.facebook.ktfmt.intellij.KtfmtFormattingService"/>
         <postStartupActivity implementation="com.facebook.ktfmt.intellij.InitialConfigurationStartupActivity"/>
+        <!--suppress PluginXmlCapitalization -->
         <projectConfigurable instance="com.facebook.ktfmt.intellij.KtfmtConfigurable"
                              id="com.facebook.ktfmt_idea_plugin.settings"
                              displayName="ktfmt Settings"

--- a/online_formatter/build.gradle.kts
+++ b/online_formatter/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   testImplementation(kotlin("test-junit"))
 }
 
-kotlin { jvmToolchain(11) }
+kotlin { jvmToolchain(17) }
 
 tasks {
   test { useJUnit() }

--- a/online_formatter/gradle.properties
+++ b/online_formatter/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2G

--- a/online_formatter/gradle/wrapper/gradle-wrapper.properties
+++ b/online_formatter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/online_formatter/src/main/kotlin/main.kt
+++ b/online_formatter/src/main/kotlin/main.kt
@@ -34,7 +34,7 @@ class Handler : RequestHandler<APIGatewayProxyRequestEvent, String> {
     return gson.toJson(
         try {
           val request = gson.fromJson(event.body, Request::class.java)
-          val style = request.style
+          val style = request?.style ?: return "{}"
           when (val parseResult = ParsedArgs.parseOptions(listOfNotNull(style).toTypedArray())) {
             is ParseResult.Ok -> {
               val parsedArgs = parseResult.parsedValue


### PR DESCRIPTION
This is step 1/2 needed to be able to run the ktlint plugin on IJ 24.2, which was just released today to stable. The next step will be to actually fix the crash on 24.2 — another PR coming for that.