### PR TITLE
Fix IntelliJ plugin on IJP 242

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,10 +30,10 @@ jobs:
     - name: Build ktfmt_idea_plugin
       run: |
         pushd ktfmt_idea_plugin
-        ./gradlew build
+        ./gradlew build --no-daemon
         popd
     - name: Build the Online Formatter
       run: |
         pushd online_formatter
-        ./gradlew build
+        ./gradlew build --no-daemon
         popd

--- a/.github/workflows/publish_artifacts_on_release.yaml
+++ b/.github/workflows/publish_artifacts_on_release.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Publish IntelliJ plugin to JetBrains Marketplace
         run: |
           pushd ktfmt_idea_plugin
-          ./gradlew publishPlugin --stacktrace
+          ./gradlew publishPlugin --stacktrace --no-daemon
           popd
         env:
           JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.*
+
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -68,3 +68,8 @@ intellijPlatform {
 }
 
 spotless { java { googleJavaFormat(libs.versions.googleJavaFormat.get()) } }
+
+val runIntellij242 by intellijPlatformTesting.runIde.registering {
+  type = IntellijIdeaCommunity
+  version = "2024.2"
+}

--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/InitialConfigurationStartupActivity.java
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/InitialConfigurationStartupActivity.java
@@ -19,6 +19,8 @@ package com.facebook.ktfmt.intellij;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import org.jetbrains.annotations.NotNull;
@@ -39,15 +41,18 @@ final class InitialConfigurationStartupActivity implements StartupActivity.Backg
 
   private void displayNewUserNotification(Project project, KtfmtSettings settings) {
     new Notification(
-            NotificationGroupManager.getInstance().getNotificationGroup(NOTIFICATION_TITLE).getDisplayId(),
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup(NOTIFICATION_TITLE)
+                .getDisplayId(),
             NOTIFICATION_TITLE,
-            "The ktfmt plugin is disabled by default. "
-                + "<a href=\"enable\">Enable for this project</a>.",
+            "The ktfmt plugin is disabled by default.",
             NotificationType.INFORMATION)
-        .setListener(
-            (n, e) -> {
-              settings.setEnabled(true);
-              n.expire();
+        .addAction(
+            new AnAction("Enable for This Project") {
+              @Override
+              public void actionPerformed(@NotNull AnActionEvent e) {
+                settings.setEnabled(true);
+              }
             })
         .notify(project);
   }

--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/InitialConfigurationStartupActivity.java
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/InitialConfigurationStartupActivity.java
@@ -40,18 +40,22 @@ final class InitialConfigurationStartupActivity implements StartupActivity.Backg
   }
 
   private void displayNewUserNotification(Project project, KtfmtSettings settings) {
-    new Notification(
+    Notification notification =
+        new Notification(
             NotificationGroupManager.getInstance()
                 .getNotificationGroup(NOTIFICATION_TITLE)
                 .getDisplayId(),
             NOTIFICATION_TITLE,
             "The ktfmt plugin is disabled by default.",
-            NotificationType.INFORMATION)
+            NotificationType.INFORMATION);
+
+    notification
         .addAction(
             new AnAction("Enable for This Project") {
               @Override
               public void actionPerformed(@NotNull AnActionEvent e) {
                 settings.setEnabled(true);
+                notification.expire();
               }
             })
         .notify(project);

--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/InitialConfigurationStartupActivity.java
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/InitialConfigurationStartupActivity.java
@@ -17,7 +17,6 @@
 package com.facebook.ktfmt.intellij;
 
 import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.project.Project;
@@ -27,12 +26,9 @@ import org.jetbrains.annotations.NotNull;
 final class InitialConfigurationStartupActivity implements StartupActivity.Background {
 
   private static final String NOTIFICATION_TITLE = "Enable ktfmt";
-  private static final NotificationGroup NOTIFICATION_GROUP =
-      NotificationGroupManager.getInstance().getNotificationGroup(NOTIFICATION_TITLE);
 
   @Override
   public void runActivity(@NotNull Project project) {
-
     KtfmtSettings settings = KtfmtSettings.getInstance(project);
 
     if (settings.isUninitialized()) {
@@ -43,7 +39,7 @@ final class InitialConfigurationStartupActivity implements StartupActivity.Backg
 
   private void displayNewUserNotification(Project project, KtfmtSettings settings) {
     new Notification(
-            NOTIFICATION_GROUP.getDisplayId(),
+            NotificationGroupManager.getInstance().getNotificationGroup(NOTIFICATION_TITLE).getDisplayId(),
             NOTIFICATION_TITLE,
             "The ktfmt plugin is disabled by default. "
                 + "<a href=\"enable\">Enable for this project</a>.",


### PR DESCRIPTION
This PR fixes the issues in IJ 24.2, where the ktfmt crashes when being loaded and is essentially non-functional. It also removes a deprecated API usage in the same file.

Closes #494