### PR TITLE
Add more settings to IJ Plugin UI

### DIFF
--- a/ktfmt_idea_plugin/src/main/kotlin/com/facebook/ktfmt/intellij/KtfmtConfigurable.kt
+++ b/ktfmt_idea_plugin/src/main/kotlin/com/facebook/ktfmt/intellij/KtfmtConfigurable.kt
@@ -16,16 +16,27 @@
 
 package com.facebook.ktfmt.intellij
 
+import com.facebook.ktfmt.format.FormattingOptions
 import com.facebook.ktfmt.intellij.KtfmtSettings.EnabledState.Disabled
 import com.facebook.ktfmt.intellij.KtfmtSettings.EnabledState.Enabled
+import com.facebook.ktfmt.intellij.UiFormatterStyle.Custom
+import com.facebook.ktfmt.intellij.UiFormatterStyle.Google
+import com.facebook.ktfmt.intellij.UiFormatterStyle.KotlinLang
+import com.facebook.ktfmt.intellij.UiFormatterStyle.Meta
 import com.intellij.openapi.options.BoundSearchableConfigurable
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.dsl.builder.BottomGap
+import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.bindIntText
 import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.layout.selected
+import com.intellij.ui.layout.selectedValueMatches
 import javax.swing.JCheckBox
+import javax.swing.JTextField
 
 @Suppress("DialogTitleCapitalization")
 class KtfmtConfigurable(project: Project) :
@@ -48,14 +59,133 @@ class KtfmtConfigurable(project: Project) :
               .component
     }
 
+    lateinit var styleComboBox: ComboBox<UiFormatterStyle>
     row {
-      comboBox(UiFormatterStyle.entries.toList())
-          .label("Code style:")
-          .bindItem(
-              getter = { settings.uiFormatterStyle },
-              setter = { settings.uiFormatterStyle = it ?: UiFormatterStyle.Meta },
-          )
-          .enabledIf(enabledCheckbox.selected)
+      styleComboBox =
+          comboBox(listOf(Meta, Google, KotlinLang, Custom))
+              .label("Code style:")
+              .bindItem(
+                  getter = { settings.uiFormatterStyle },
+                  setter = { settings.uiFormatterStyle = it ?: Meta },
+              )
+              .enabledIf(enabledCheckbox.selected)
+              .component
     }
+
+    group("Custom style") {
+          lateinit var maxLineLength: JTextField
+          row("Max line length:") {
+            maxLineLength =
+                textField()
+                    .bindIntText(settings::customMaxLineLength)
+                    .validatePositiveIntegerOrEmpty()
+                    .component
+          }
+
+          lateinit var blockIndent: JTextField
+          row("Block indent size:") {
+            blockIndent =
+                textField()
+                    .bindIntText(settings::customBlockIndent)
+                    .validatePositiveIntegerOrEmpty()
+                    .component
+          }
+
+          lateinit var continuationIndent: JTextField
+          row("Continuation indent size:") {
+            continuationIndent =
+                textField()
+                    .bindIntText(settings::customContinuationIndent)
+                    .validatePositiveIntegerOrEmpty()
+                    .component
+          }
+
+          lateinit var manageTrailingCommas: JCheckBox
+          row {
+            manageTrailingCommas =
+                checkBox("Manage trailing commas")
+                    .bindSelected(settings::customManageTrailingCommas)
+                    .component
+          }
+
+          lateinit var removeUnusedImports: JCheckBox
+          row {
+                removeUnusedImports =
+                    checkBox("Remove unused imports")
+                        .bindSelected(settings::customRemoveUnusedImports)
+                        .component
+              }
+              .bottomGap(BottomGap.SMALL)
+
+          row("Copy from:") {
+            // Note: updating must be done via the components, and not the settings,
+            // or the Kotlin DSL bindings will overwrite the values when applying
+            link(Meta.toString()) {
+                  UiFormatterStyle.getStandardFormattingOptions(Meta)
+                      .updateFields(
+                          maxLineLength,
+                          blockIndent,
+                          continuationIndent,
+                          manageTrailingCommas,
+                          removeUnusedImports,
+                      )
+                }
+                .component
+                .autoHideOnDisable = false
+
+            link(Google.toString()) {
+                  UiFormatterStyle.getStandardFormattingOptions(Google)
+                      .updateFields(
+                          maxLineLength,
+                          blockIndent,
+                          continuationIndent,
+                          manageTrailingCommas,
+                          removeUnusedImports,
+                      )
+                }
+                .component
+                .autoHideOnDisable = false
+
+            link(KotlinLang.toString()) {
+                  UiFormatterStyle.getStandardFormattingOptions(KotlinLang)
+                      .updateFields(
+                          maxLineLength,
+                          blockIndent,
+                          continuationIndent,
+                          manageTrailingCommas,
+                          removeUnusedImports,
+                      )
+                }
+                .component
+                .autoHideOnDisable = false
+          }
+        }
+        .visibleIf(styleComboBox.selectedValueMatches { it == Custom })
+        .enabledIf(enabledCheckbox.selected)
   }
+}
+
+private fun FormattingOptions.updateFields(
+    maxLineLength: JTextField,
+    blockIndent: JTextField,
+    continuationIndent: JTextField,
+    manageTrailingCommas: JCheckBox,
+    removeUnusedImports: JCheckBox,
+) {
+  maxLineLength.text = maxWidth.toString()
+  blockIndent.text = this.blockIndent.toString()
+  continuationIndent.text = this.continuationIndent.toString()
+  manageTrailingCommas.isSelected = this.manageTrailingCommas
+  removeUnusedImports.isSelected = this.removeUnusedImports
+}
+
+private fun Cell<JTextField>.validatePositiveIntegerOrEmpty() = validationOnInput { jTextField ->
+  if (jTextField.text.isNotEmpty()) {
+    val parsedValue = jTextField.text.toIntOrNull()
+    when {
+      parsedValue == null -> error("Value must be an integer. Will default to 1")
+      parsedValue <= 0 -> error("Value must be greater than zero. Will default to 1")
+      else -> null
+    }
+  } else null
 }

--- a/ktfmt_idea_plugin/src/main/kotlin/com/facebook/ktfmt/intellij/KtfmtSettingsMigration.kt
+++ b/ktfmt_idea_plugin/src/main/kotlin/com/facebook/ktfmt/intellij/KtfmtSettingsMigration.kt
@@ -1,0 +1,56 @@
+package com.facebook.ktfmt.intellij
+
+import com.facebook.ktfmt.intellij.KtfmtSettings.EnabledState.Disabled
+import com.facebook.ktfmt.intellij.KtfmtSettings.EnabledState.Enabled
+import com.facebook.ktfmt.intellij.KtfmtSettings.EnabledState.Unknown
+import com.facebook.ktfmt.intellij.KtfmtSettingsMigration.MigrationState
+import com.intellij.openapi.components.BaseState
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.SimplePersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.StoragePathMacros
+
+@Service(Service.Level.PROJECT)
+@State(name = "KtfmtSettingsMigration", storages = [(Storage(StoragePathMacros.WORKSPACE_FILE))])
+internal class KtfmtSettingsMigration :
+    SimplePersistentStateComponent<MigrationState>(MigrationState()) {
+
+  // ---------
+  // Changelog
+  // ---------
+  //
+  // v2 enabled [bool] -> enableKtfmt [enum], custom styles (0.52+)
+  // v1 initial version - enabled is a boolean, only preset styles
+  var stateVersion
+    get() = state.stateVersion.takeIf { it > 0 } ?: 1
+    set(value) {
+      state.stateVersion = value
+    }
+
+  @Suppress("DEPRECATION") // Accessing deprecated properties
+  fun migrateFromV1ToCurrent(v1State: KtfmtSettings.State): KtfmtSettings.State {
+    val migrated =
+        KtfmtSettings.State().apply {
+          copyFrom(v1State)
+
+          enableKtfmt =
+              when (v1State.enabled) {
+                "true" -> Enabled
+                "false" -> Disabled
+                else -> Unknown
+              }
+          enabled = null
+        }
+    state.stateVersion = CURRENT_VERSION
+    return migrated
+  }
+
+  class MigrationState : BaseState() {
+    var stateVersion by property(-1)
+  }
+
+  companion object {
+    const val CURRENT_VERSION = 2
+  }
+}

--- a/ktfmt_idea_plugin/src/main/kotlin/com/facebook/ktfmt/intellij/UiFormatterStyle.kt
+++ b/ktfmt_idea_plugin/src/main/kotlin/com/facebook/ktfmt/intellij/UiFormatterStyle.kt
@@ -22,13 +22,21 @@ import com.facebook.ktfmt.format.Formatter.META_FORMAT
 import com.facebook.ktfmt.format.FormattingOptions
 
 /** Configuration options for the formatting style. */
-internal enum class UiFormatterStyle(
-    private val description: String,
-    val formattingOptions: FormattingOptions,
-) {
-  Meta("Meta (default)", META_FORMAT),
-  Google("Google (internal)", GOOGLE_FORMAT),
-  KotlinLang("Kotlinlang", KOTLINLANG_FORMAT);
+internal enum class UiFormatterStyle(private val description: String) {
+  Meta("Meta (default)"),
+  Google("Google (internal)"),
+  KotlinLang("Kotlinlang"),
+  Custom("Custom");
 
   override fun toString(): String = description
+
+  companion object {
+    internal fun getStandardFormattingOptions(style: UiFormatterStyle): FormattingOptions =
+        when (style) {
+          Meta -> META_FORMAT
+          Google -> GOOGLE_FORMAT
+          KotlinLang -> KOTLINLANG_FORMAT
+          Custom -> error("Custom style formatting options should be retrieved separately")
+        }
+  }
 }


### PR DESCRIPTION
As discussed on Slack, this PR exposes the existing settings (`FormattingOptions`) in the IJ plugin UI. This brings the IJ plugin in line with the Gradle one.

There is also a migration from the old settings (`enabled` as a boolean) to the new ones (`enableKtfmt` as an enum) that allows us to drop a bunch of legacy code and use better, Kotlin-friendly APIs. I (manually) tested both migrating from old settings (enabled and disabled) and starting anew, and it works fine. I have already used a similar strategy in the detekt plugin, and it worked well there, too.

## The new Custom option

https://github.com/user-attachments/assets/215f7e05-86a5-46d1-9cd7-4495fd3395d1

When selecting the Custom option, users can freely choose a max line length, indent/continuation indent size, and whether ktfmt should be managing imports and trailing commas. The UI will display validation errors if the numeric values are invalid (not shown above). It also allows to use one of the presets as starting points for customizing, which I expect will be a pretty common use case — e.g., I may want to use Meta's style, but with longer lines.