### PR TITLE
bump nexus-staging-maven plugin to 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.13</version>
+            <version>1.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>


### PR DESCRIPTION
1.6.13 does not work with jdk 17 which is needed on CI now for the idea build.

I hope this works because I can not really test it locally. 