### PR TITLE
Support context parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - Support guard conditions (https://github.com/facebook/ktfmt/issues/530, https://github.com/facebook/ktfmt/pull/537)
+- Support context parameters (https://github.com/facebook/ktfmt/issues/518, https://github.com/facebook/ktfmt/pull/536)
 - Update `kotlin-compiler-embeddable` to `2.2.0-Beta2` for forward compatibility with context parameters. (https://github.com/facebook/ktfmt/pull/538)
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
 
   <properties>
     <dokka.version>0.10.1</dokka.version>
-    <kotlin.version>2.0.21</kotlin.version>
+    <kotlin.version>2.2.0-Beta2</kotlin.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     <main.class>com.facebook.ktfmt.cli.Main</main.class>

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1689,12 +1689,19 @@ class KotlinInputAstVisitor(
     builder.forcedBreak()
   }
 
-  /** Example `context(Logger, Raise<Error>)` */
+  /**
+   * Example `context(logger: Logger, raise: Raise<Error>)`
+   *
+   * Note this also supports the legacy receiver format of `context(Logger, Raise<Error>)`
+   * for backward compatibility.
+   */
   override fun visitContextReceiverList(contextReceiverList: KtContextReceiverList) {
     builder.sync(contextReceiverList)
     builder.token("context")
+    val listToVisit =
+        contextReceiverList.contextParameters().ifEmpty { contextReceiverList.contextReceivers() }
     visitEachCommaSeparated(
-        contextReceiverList.contextReceivers(),
+        listToVisit,
         prefix = "(",
         postfix = ")",
         breakAfterPrefix = false,

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1692,8 +1692,8 @@ class KotlinInputAstVisitor(
   /**
    * Example `context(logger: Logger, raise: Raise<Error>)`
    *
-   * Note this also supports the legacy receiver format of `context(Logger, Raise<Error>)`
-   * for backward compatibility.
+   * Note this also supports the legacy receiver format of `context(Logger, Raise<Error>)` for
+   * backward compatibility.
    */
   override fun visitContextReceiverList(contextReceiverList: KtContextReceiverList) {
     builder.sync(contextReceiverList)

--- a/core/src/main/java/com/facebook/ktfmt/format/Parser.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/Parser.kt
@@ -16,7 +16,6 @@
 
 package com.facebook.ktfmt.format
 
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer.PLAIN_RELATIVE_PATHS
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -26,6 +25,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtil
 import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiManager
 import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtFile
@@ -51,7 +51,7 @@ object Parser {
     val disposable = Disposer.newDisposable()
     val configuration = CompilerConfiguration()
     configuration.put(
-        CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
+        CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
         PrintingMessageCollector(System.err, PLAIN_RELATIVE_PATHS, false))
     env =
         KotlinCoreEnvironment.createForProduction(

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -7394,6 +7394,63 @@ class FormatterTest {
   }
 
   @Test
+  fun `context parameters`() {
+    val code =
+        """
+      |context(something: Something)
+      |
+      |class A {
+      |  context(
+      |  // Test comment.
+      |  logger: Logger, raise: Raise<Error>, _: Ignored)
+      |
+      |  @SomeAnnotation
+      |
+      |  fun doNothing() {}
+      |
+      |  context(somethingElse: SomethingElse)
+      |
+      |  private class NestedClass {}
+      |
+      |  fun <T> testSuspend(
+      |    mock: T,
+      |    block: suspend context(someContext: SomeContext) T.() -> Unit,
+      |  ) = startCoroutine {
+      |    T.block()
+      |  }
+      |}
+      |"""
+            .trimMargin()
+
+    val expected =
+        """
+      |context(something: Something)
+      |class A {
+      |  context(
+      |  // Test comment.
+      |  logger: Logger,
+      |  raise: Raise<Error>,
+      |  _: Ignored)
+      |  @SomeAnnotation
+      |  fun doNothing() {}
+      |
+      |  context(somethingElse: SomethingElse)
+      |  private class NestedClass {}
+      |
+      |  fun <T> testSuspend(
+      |      mock: T,
+      |      block:
+      |          suspend context(someContext: SomeContext)
+      |          T.() -> Unit,
+      |  ) = startCoroutine { T.block() }
+      |}
+      |"""
+            .trimMargin()
+
+    assertThatFormatting(code).isEqualTo(expected)
+  }
+
+  @Test
   fun `trailing comment after function in class`() =
       assertFormatted(
           """

--- a/core/src/test/java/com/facebook/ktfmt/format/TokenizerTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/TokenizerTest.kt
@@ -221,6 +221,129 @@ class TokenizerTest {
   }
 
   @Test
+  fun `Context parameters are parsed correctly`() {
+    val code =
+        """
+      |context(something: Something)
+      |class A {
+      |  context(
+      |  // Test comment.
+      |  logger: Logger, raise: Raise<Error>, _: Ignored)
+      |  fun test() {}
+      |}
+      |"""
+            .trimMargin()
+            .trimMargin()
+
+    val file = Parser.parse(code)
+    val tokenizer = Tokenizer(code, file)
+    file.accept(tokenizer)
+
+    assertThat(tokenizer.toks.map { it.originalText })
+        .containsExactly(
+            "context",
+            "(",
+            "something",
+            ":",
+            " ",
+            "Something",
+            ")",
+            "\n",
+            "class",
+            " ",
+            "A",
+            " ",
+            "{",
+            "\n",
+            "  ",
+            "context",
+            "(",
+            "\n",
+            "  ",
+            "// Test comment.",
+            "\n",
+            "  ",
+            "logger",
+            ":",
+            " ",
+            "Logger",
+            ",",
+            " ",
+            "raise",
+            ":",
+            " ",
+            "Raise",
+            "<",
+            "Error",
+            ">",
+            ")",
+            "\n",
+            "  ",
+            "fun",
+            " ",
+            "test",
+            "(",
+            ")",
+            " ",
+            "{",
+            "}",
+            "\n",
+            "}")
+        .inOrder()
+    assertThat(tokenizer.toks.map { it.index })
+        .containsExactly(
+            0,
+            1,
+            2,
+            3,
+            -1,
+            4,
+            5,
+            -1,
+            6,
+            -1,
+            7,
+            -1,
+            8,
+            -1,
+            -1,
+            9,
+            10,
+            -1,
+            -1,
+            11,
+            -1,
+            -1,
+            12,
+            13,
+            -1,
+            14,
+            15,
+            -1,
+            16,
+            17,
+            -1,
+            18,
+            19,
+            20,
+            21,
+            22,
+            -1,
+            -1,
+            23,
+            -1,
+            24,
+            25,
+            26,
+            -1,
+            27,
+            28,
+            -1,
+            29)
+        .inOrder()
+  }
+
+  @Test
   fun `Unclosed comment obvious`() {
     assertParseError(
         """

--- a/core/src/test/java/com/facebook/ktfmt/format/TokenizerTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/TokenizerTest.kt
@@ -501,7 +501,7 @@ class TokenizerTest {
 
   @Test
   fun `Context parameters are parsed correctly`() {
-    //language=kotlin
+    // language=kotlin
     val code =
         """
       |context(something: Something)
@@ -555,6 +555,12 @@ class TokenizerTest {
             "<",
             "Error",
             ">",
+            ",",
+            " ",
+            "_",
+            ":",
+            " ",
+            "Ignored",
             ")",
             "\n",
             "  ",
@@ -567,7 +573,9 @@ class TokenizerTest {
             "{",
             "}",
             "\n",
-            "}")
+            "}",
+            "\n",
+        )
         .inOrder()
     assertThat(tokenizer.toks.map { it.index })
         .containsExactly(
@@ -608,17 +616,25 @@ class TokenizerTest {
             21,
             22,
             -1,
-            -1,
             23,
-            -1,
             24,
+            -1,
             25,
             26,
             -1,
-            27,
-            28,
             -1,
-            29)
+            27,
+            -1,
+            28,
+            29,
+            30,
+            -1,
+            31,
+            32,
+            -1,
+            33,
+            -1,
+        )
         .inOrder()
   }
 

--- a/core/src/test/java/com/facebook/ktfmt/format/TokenizerTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/TokenizerTest.kt
@@ -222,6 +222,7 @@ class TokenizerTest {
 
   @Test
   fun `Context parameters are parsed correctly`() {
+    //language=kotlin
     val code =
         """
       |context(something: Something)
@@ -232,7 +233,6 @@ class TokenizerTest {
       |  fun test() {}
       |}
       |"""
-            .trimMargin()
             .trimMargin()
 
     val file = Parser.parse(code)


### PR DESCRIPTION
Resolves #518

Note that in order for `LightVirtualFile` to correctly parse this, it did require updating to the Kotlin 2.2.0 betas. Since this ships as a fat jar I think it would be fine to build against this in `main`, but up to y'all!

This adds a couple new tests for it + ensures backward compatibility with the previous context receivers syntax.